### PR TITLE
Selenium 대신 requests 이용

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 - `pip install pandas`
 - `pip install bs4`
-- `pip install selenium`
+- `pip install requests`
 - `pip install flask`
 - `pip install schedule`
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## ✔️프로젝트 소개
 
-- `selenium`을 이용한 데이터 스크래핑을 이용하여 학식 메뉴를 불러와서 `table.csv`파일로 저장 후 호출마다 알려줌
+- `requests`을 이용한 데이터 스크래핑을 이용하여 학식 메뉴를 불러와서 `table.csv`파일로 저장 후 호출마다 알려줌
 - `Flask`를 사용해서 **POST** 요청 처리 후 정해진 Json 파일로 클라이언트에게 전송한다.
 
 ## ✔️프로젝트 실행방법
@@ -22,6 +22,7 @@
 - `pip install bs4`
 - `pip install selenium`
 - `pip install flask`
+- `pip install schedule`
 
 ## ✔️추후 추가기능
 

--- a/hamjimaru/menu.py
+++ b/hamjimaru/menu.py
@@ -1,70 +1,27 @@
 #-*- coding: utf-8 -*-
 #!/usr/bin/env python3
-from selenium import webdriver
-from urllib.request import urlopen
 from bs4 import BeautifulSoup
-from html_table_parser import parser_functions as parser
 import pandas as pd
 import datetime
-from pandas import Series, DataFrame
+import requests
 import time
 import schedule
 
-chrome_options = webdriver.ChromeOptions()
-chrome_options.add_argument('--no--sandbox')
-chrome_options.add_argument("--single-process")
-chrome_options.add_argument('--headless')
-chrome_options.add_argument("--disable-dev-shm-usage")
+headers = {
+	"user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.82 Safari/537.36"
+}
 
-def remove_residue(string):
-	removed = ""
-	for i in range(len(string)):
-		if string[i] == '\n':
-			if string[i + 1] == '\n':
-				break
-		removed += string[i]
-	return removed
-
-
-# chromedriver 경로설정
-chromedriver = './chromedriver'
-driver = webdriver.Chrome(chromedriver, options=chrome_options)
 def job():
-	driver.implicitly_wait(1)
-	driver.get('https://www.kw.ac.kr/ko/life/facility11.jsp')  # 스크래핑할 url 입력
-	driver.implicitly_wait(1)
+	r = requests.get('https://www.kw.ac.kr/ko/life/facility11.jsp', headers=headers)
+	soup = BeautifulSoup(r.text, 'html.parser')
+	table = soup.find('table', {'class': 'tbl-list'})
+	thead = table.find('thead')
+	tbody = table.find('tbody')
 
-	table = driver.find_element_by_xpath("//*[@id=\"item_body\"]/div[3]/div/div[1]/article/div[3]/div/section/div/table")
-	thead = table.find_elements_by_tag_name("thead")
-	tbody = table.find_elements_by_tag_name("tbody")
-
-	for tr in thead:
-		th= tr.find_elements_by_tag_name("th")
-		mon=th[1].text
-		tue=th[2].text
-		wed=th[3].text
-		thu=th[4].text
-		fri=th[5].text
-
-	#print("first command")
-	#print('월:{0}, 화:{1}, 수:{2}, 목:{3}, 금:{4}'.format(mon,tue,wed,thu,fri))
-		diet1 =[mon, tue, wed, thu, fri]
-		m1={mon,tue,wed,thu,fri}    
-		
-	for tr in tbody:
-		td= tr.find_elements_by_tag_name("td")
-		mon = remove_residue(td[1].text)
-		tue = remove_residue(td[2].text)
-		wed = remove_residue(td[3].text)
-		thu = remove_residue(td[4].text)
-		fri = remove_residue(td[5].text)
-
-
-	#print("second command")
-	#print('월:{0}, 화:{1}, 수:{2}, 목:{3}, 금:{4}'.format(mon,tue,wed,thu,fri))
-		diet2 =[mon, tue, wed, thu, fri]
-
+	diet1 = map(lambda node: node.text.replace("\n",""), thead.findAll("th")[1:])
+	diet2 = map(lambda node: node.text, tbody.findAll("td")[1:])
 	data= [diet1,diet2]
+	
 	toSave = pd.DataFrame(data)
 	toSave.to_csv("./table.csv", index=False, header=False, encoding="utf-8")
 
@@ -74,9 +31,8 @@ def job():
 		f.write("["+now+"] "+"update the diet!\n")
 		f.close()
 
-schedule.every(3).hours.do(job);
+schedule.every(3).hours.do(job)
 
 while True:
 	schedule.run_pending()
 	time.sleep(1)
-driver.close()


### PR DESCRIPTION
`Selenium`은 웹드라이버 프로그램을 이용하기때문에 기본적으로 무겁지만, `requests` 모듈을 이용하면 단순히 HTTP(S) 요청으로 필요한 것만 요청하기 때문에 훨씬 가벼워 집니다.

확인해보니 [광운대학교 식단 홈페이지](https://www.kw.ac.kr/ko/life/facility11.jsp)는 동적 웹사이트가 아닌 정적 웹사이트이기 때문에, 궃이 Selenium 으로 가상의 웹을 띄울 필요없이 requests로 필요한 HTML 파일만 가져다 쓰면 됩니다. 

그 외에도 README에 빠진 의존성 `schedule`이 있어서 추가했습니다.
